### PR TITLE
use the power of shuf

### DIFF
--- a/strategy.sh
+++ b/strategy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-shuf -n $(wc -l strategies.txt | awk '{print $1}') strategies.txt | head -1
+shuf -n1 strategies.txt


### PR DESCRIPTION
The -n argument for shuf is meant to decide how many output lines do
we wont. So, we don't need to use either wc or head, shuf can do all
we want for us.

This patch maintains exactly the same functionality, but simplifies
the script.